### PR TITLE
Adding documentation: "Using the RDA Annotator" 

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,3 +10,15 @@
     ]
   }
 ]
+[
+  {
+    "group": "Systems and Tools",
+    "materials": [
+      {
+        "topic": "Using the RDA Annotator",
+        "type": "PDF",
+        "url": "https://dans-knaw.github.io/RDA-TIGER-PDFs/3.3.7%20-%20Annotator%20support%20documentation%20-%20v0.2.pdf"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Adding here the "Using the RDA Annotator" documentation, including a download link. Also known internally as "Annotator support documentation." We should agree on the usage of internal vs. user-facing names on GitHub, or make sure that names don't differ in the first place. 

This document may need to be updated. For now, using it more as a test case, and also important to make the download link available. I hope I managed to follow the file management procedure. Best /Simon 